### PR TITLE
Bugfix

### DIFF
--- a/hungarian.c
+++ b/hungarian.c
@@ -479,7 +479,7 @@ static int solver(lua_State *L)
   hungarian_free(&p);
 
   int idx;
-  for (idx=0; idx < 4; idx+=1) {
+  for (idx=0; idx < w; idx+=1) {
     free(m[idx]);
   }
   free(m);

--- a/hungarian.c
+++ b/hungarian.c
@@ -479,7 +479,7 @@ static int solver(lua_State *L)
   hungarian_free(&p);
 
   int idx;
-  for (idx=0; idx < w; idx+=1) {
+  for (idx=0; idx < h; idx+=1) {
     free(m[idx]);
   }
   free(m);


### PR DESCRIPTION
Remove a hardcoded '4' in the solver for freeing memory. Causes code to break on small matrices and does not free space on larger matrices.